### PR TITLE
[CDTCommon] Minor QOL changes

### DIFF
--- a/cdtcommon/cdtcommon.py
+++ b/cdtcommon/cdtcommon.py
@@ -125,7 +125,7 @@ class CdtCommon(commands.Cog):
         return members or None
 
     def _get_controls(self, list: list, export: bool = False):
-        controls = set()
+        controls = dict()
         if len(list) < 5:
             controls.update({
                 "<:arrowleft:735628703610044488>": menus.prev_page,

--- a/cdtcommon/cdtcommon.py
+++ b/cdtcommon/cdtcommon.py
@@ -5,6 +5,8 @@ from redbot.core.utils import menus, chat_formatting
 from .cdtembed import Embed
 import random
 
+from typing import Optional
+
 
 class CdtCommon(commands.Cog):
     """
@@ -14,7 +16,7 @@ class CdtCommon(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.cdtguild = self.bot.get_guild(215271081517383682)
-        self.Embed = Embed(self)
+        self.Embed = Embed(self.bot)
         self.config = Config.get_conf(
             self,
             identifier=8675309,
@@ -80,11 +82,11 @@ class CdtCommon(commands.Cog):
             # menu = PagesMenu(self.bot, timeout=30, add_pageof=True)
             # await menu.menu_start(pages=pages)
 
-    @commands.command(pass_context=True, no_pm=True)
+    @commands.command()
+    @commands.guild_only()
     async def showtopic(self, ctx, channel: discord.TextChannel = None):
         """Show the Channel Topic in the chat channel as a CDT Embed."""
-        if channel is None:
-            channel = ctx.message.channel
+        channel = channel or ctx.channel
         topic = channel.topic
         if topic is not None and topic != '':
             data = self.Embed.create(ctx, title='#{} Topic :sparkles:'.format(
@@ -92,52 +94,43 @@ class CdtCommon(commands.Cog):
                                      description=topic)
             data.set_thumbnail(url=ctx.message.guild.icon_url)
             await ctx.send(embed=data)
+        else:
+            await ctx.send("That channel does not have a topic")
 
-    @commands.command(pass_context=True, name='list_members', aliases=('list_users',))
-    async def _users_by_role(self, ctx, role: discord.Role, use_alias=True):
+    @commands.command(name='listmembers', aliases=('listusers', "roleroster", "rr"))
+    async def _users_by_role(self, ctx, use_alias: Optional[bool] = True, *, role: discord.Role):
         '''Embed a list of server users by Role'''
-        guild = ctx.message.guild
+        guild = ctx.guild
         pages = []
-        members = self._list_users(ctx, role, ctx.message.guild)
+        members = self._list_users(ctx, role, guild)
         if members is not None:
             if use_alias is True:
                 ret = '\n'.join('{0.display_name}'.format(m) for m in members)
             else:
                 ret = '\n'.join('{0.name} [{0.id}]'.format(m) for m in members)
-            pagified = chat_formatting.pagify(ret)
-            # if use_alias:
-            #     ret = '\n'.join([m.display_name for m in members])
-            # else:
-            #     ret = '\n'.join([m.name for m in members])
-            for page in pagified:
+            for page in chat_formatting.pagify(ret):
                 data = self.Embed.create(ctx, title='{0.name} Role - {1} member(s)'.format(role, len(members)),
                                          description=page)
                 pages.append(data)
             if len(pages) == 1:
                 await ctx.send(embed=data)
-            # elif len(pages) > 1:
-            #     await menus.menu(ctx=ctx, pages=pages, controls=self._get_controls(pages))
+            else:
+                await menus.menu(ctx=ctx, pages=pages, controls=self._get_controls(pages))
+        else:
+            await ctx.send(f"I could not find any members with the role {role.name}.")
 
     def _list_users(self, ctx, role: discord.Role, guild: discord.guild):
         """Given guild and role, return member list"""
-        members = []
-        for member in guild.members:
-            if role in member.roles:
-                members.append(member)
-        if len(members) > 0:
-            return members
-        else:
-            return None
+        members = [m for m in guild.members if role in m.roles]
+        return members or None
 
     def _get_controls(self, list: list, export: bool = False):
-        controls = {}
+        controls = set()
         if len(list) < 5:
             controls.update({
-                # "<:arrowsleft:735628703824085004>" : menus.prev_page,
                 "<:arrowleft:735628703610044488>": menus.prev_page,
                 "<:circlex:735628703530483814>": menus.close_menu,
                 "<:arrowright:735628703840600094>": menus.next_page
-                # "<:arrowsright:735628703609913396>": menus.next_page
             })
         elif len(list) >= 5:
             controls.update({


### PR DESCRIPTION
- [x] Allows users to know when a role roster is empty
- [x] Allows users to know when a channel has no topic
- [x] Minor updates to function in general
- [x] Guild only check instead of `no_pm=True` inside command decorator
- [x] `typing.Optional[bool]` and `*, role` to allow for multi-worded role names (easier to type without mentioning the role)

Have any questions or change requests feel free to ask